### PR TITLE
Support for using Ebay Sandbox urls outside of production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,4 @@ end
   
 group :development do
   gem 'rspec'
-  gem 'bundler', '>= 1.0.0'
-  gem 'jeweler', '>= 1.5.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
-    git (1.2.5)
-    jeweler (1.5.2)
-      bundler (~> 1.0.0)
-      git (>= 1.2.5)
-      rake
     json (1.5.1)
-    rake (0.8.7)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -17,14 +11,10 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
-    watchr (0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.0.0)
-  jeweler (>= 1.5.2)
   json
   rspec
-  watchr

--- a/lib/rebay/api.rb
+++ b/lib/rebay/api.rb
@@ -5,13 +5,30 @@ require 'uri'
 module Rebay
   class Api
     EBAY_US = 0
-  
+
+    BASE_URL_PREFIX = "http://svcs"
+    BASE_URL_SUFFIX = "ebay.com"
+
+    def self.base_url
+      [BASE_URL_PREFIX,
+       sandbox ? "sandbox" : nil,
+       BASE_URL_SUFFIX].compact.join('.')
+    end
+    
     def self.app_id= app_id
       @@app_id = app_id
     end
     
     def self.app_id
       @@app_id
+    end
+
+    def self.sandbox= sandbox
+      @@sandbox = sandbox
+    end
+
+    def self.sandbox
+      @@sandbox ||= false
     end
       
     def self.configure

--- a/lib/rebay/finding.rb
+++ b/lib/rebay/finding.rb
@@ -1,6 +1,7 @@
 module Rebay
   class Finding < Rebay::Api
-    BASE_URL = 'http://svcs.ebay.com/services/search/FindingService/v1'
+    BASE_URL_PREFIX = 'http://svcs'
+    BASE_URL_SUFFIX = 'ebay.com/services/search/FindingService/v1'
     VERSION = '1.0.0'
     
     #http://developer.ebay.com/DevZone/finding/CallRef/findItemsAdvanced.html
@@ -91,7 +92,7 @@ module Rebay
     
     private    
     def build_request_url(service, params=nil)
-      url = "#{BASE_URL}?OPERATION-NAME=#{service}&SERVICE-VERSION=#{VERSION}&SECURITY-APPNAME=#{Rebay::Api.app_id}&RESPONSE-DATA-FORMAT=JSON&REST-PAYLOAD"
+      url = "#{self.class.base_url}?OPERATION-NAME=#{service}&SERVICE-VERSION=#{VERSION}&SECURITY-APPNAME=#{Rebay::Api.app_id}&RESPONSE-DATA-FORMAT=JSON&REST-PAYLOAD"
       url += build_rest_payload(params)
       return url
     end

--- a/lib/rebay/shopping.rb
+++ b/lib/rebay/shopping.rb
@@ -1,6 +1,7 @@
 module Rebay
   class Shopping < Rebay::Api
-    BASE_URL = 'http://open.api.ebay.com/shopping'
+    BASE_URL_PREFIX = "http://open.api"
+    BASE_URL_SUFFIX = "ebay.com/shopping"
     VERSION = '677'
     
     #http://developer.ebay.com/DevZone/shopping/docs/CallRef/FindProducts.html
@@ -117,7 +118,7 @@ module Rebay
     
     private
     def build_request_url(service, params=nil)
-      url = "#{BASE_URL}?callname=#{service}&appid=#{Rebay::Api.app_id}&version=#{VERSION}&responseencoding=JSON&siteid=#{Rebay::Api::EBAY_US}"
+      url = "#{self.class.base_url}?callname=#{service}&appid=#{Rebay::Api.app_id}&version=#{VERSION}&responseencoding=JSON&siteid=#{Rebay::Api::EBAY_US}"
       url += build_rest_payload(params)
       return url
     end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -2,6 +2,40 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 module Rebay
   describe Api do
+    describe Api::BASE_URL_PREFIX do
+      it "shouldn't be nil" do
+        Rebay::Api::BASE_URL_PREFIX.should_not be_nil
+      end
+    end
+
+    describe Api::BASE_URL_SUFFIX do
+      it "shouldn't be nil" do
+        Rebay::Api::BASE_URL_SUFFIX.should_not be_nil
+      end
+    end
+
+    describe "#base_url" do
+      context "api calls should hit the sandbox" do
+        it "should return a sandboxed url" do
+          Rebay::Api.configure do |c|
+            c.sandbox = true
+          end
+          
+          Rebay::Api.base_url.should include "sandbox"
+        end
+      end
+
+      context "api calls shouldn't hit the sandbox" do
+        it "should return a un-sandboxed url" do
+          Rebay::Api.configure do |c|
+            c.sandbox = false
+          end
+
+          Rebay::Api.base_url.should_not include "sandbox"
+        end
+      end
+    end
+    
     it "should respond to configure" do
       Rebay::Api.should respond_to(:configure)
     end
@@ -13,11 +47,11 @@ module Rebay
     it "should allow getting of app_id" do
       Rebay::Api.should respond_to(:app_id)
     end
-    
+
     it "should return app id after configureation" do
       app_id = Rebay::Api.app_id
       Rebay::Api.configure do |rebay|
-        rebay.app_id = 'test'
+        rebay.app_id = 'test'        
       end
       Rebay::Api.app_id.should == 'test'
       Rebay::Api.configure do |rebay|

--- a/spec/finding_spec.rb
+++ b/spec/finding_spec.rb
@@ -6,9 +6,9 @@ module Rebay
         @finder = Finding.new
         @finder.stub!(:get_json_response).and_return(Rebay::Response.new({"Ack" => 'Success'}))
     end
-      
+
     it "should specify base url" do
-      Finding::BASE_URL.should_not be_nil
+      Finding.base_url.should_not be_nil
     end
     
     it "should specify version" do

--- a/spec/shopping_spec.rb
+++ b/spec/shopping_spec.rb
@@ -6,9 +6,9 @@ module Rebay
       @shopper = Shopping.new
       @shopper.stub!(:get_json_response).and_return(Rebay::Response.new({"Ack" => "Success"}))
     end
-      
+
     it "should specify base url" do
-      Shopping::BASE_URL.should_not be_nil
+      Shopping.base_url.should_not be_nil
     end
     
     it "should specify version" do


### PR DESCRIPTION
To allow the use of Ebay Sandbox urls as api endpoints, I added a configuration variable and changed the way the api classes generate their base urls.
