### PR TITLE
Allow array params

### DIFF
--- a/lib/rebay/api.rb
+++ b/lib/rebay/api.rb
@@ -10,7 +10,7 @@ module Rebay
 
     class << self
       attr_accessor :app_id, :default_site_id, :sandbox
-      
+
       def base_url
         [base_url_prefix,
          sandbox ? "sandbox" : nil,
@@ -28,18 +28,18 @@ module Rebay
       def sandbox
         @sandbox ||= false
       end
-      
+
       def default_site_id
         @default_site_id || EBAY_US
       end
-      
+
       def configure
         yield self if block_given?
       end
     end
 
     protected
-    
+
     def get_json_response(url)
       Rebay::Response.new(JSON.parse(Net::HTTP.get_response(URI.parse(url)).body))
     end
@@ -48,7 +48,14 @@ module Rebay
       payload = ''
       unless params.nil?
         params.keys.each do |key|
-          payload += URI.escape "&#{key}=#{params[key]}"
+          if params[key].is_a?(Array)
+            params[key].each_with_index do |object, index|
+              payload += URI.escape "&#{key}(#{index}).name=#{object[:name]}"
+              payload += URI.escape "&#{key}(#{index}).value=#{object[:value]}"
+            end
+          else
+            payload += URI.escape "&#{key}=#{params[key]}"
+          end
         end
       end
       return payload

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -7,7 +7,7 @@ module Rebay
       it "should respond to configure" do
         Rebay::Api.should respond_to(:configure)
       end
-      
+
       describe "#base_url_prefix" do
         it "shouldn't be nil" do
           Rebay::Api.base_url_prefix.should_not be_nil
@@ -19,14 +19,14 @@ module Rebay
           Rebay::Api.base_url_suffix.should_not be_nil
         end
       end
-      
+
       describe "#base_url" do
         context "api calls should hit the sandbox" do
           it "should return a sandboxed url" do
             Rebay::Api.configure do |c|
               c.sandbox = true
             end
-          
+
             Rebay::Api.base_url.should include "sandbox"
           end
         end
@@ -45,7 +45,7 @@ module Rebay
       describe "#sandbox" do
         it_behaves_like "a configuration option", :sandbox, true
       end
-      
+
       describe "#app_id" do
         it_behaves_like "a configuration option", :app_id, 'super_id-11'
       end
@@ -77,7 +77,17 @@ module Rebay
          payload.should include("&test2=blah")
          payload.should include("&test3=blah%20blah")
       end
+
+      it 'should correctly handle arrays in the hash' do
+        hash = {:test=>'blah',
+                :test2=>[{:name=>'filter1', :value=>1},
+                         {:name=>'filter2', :value=>'true'}]}
+        payload = @api.send(:build_rest_payload, hash)
+        payload.should include("&test=blah")
+        payload.should include("&test2(0).name=filter1&test2(0).value=1")
+        payload.should include("&test2(1).name=filter2&test2(1).value=true")
+      end
     end
   end
 end
-    
+


### PR DESCRIPTION
This change allows one to setup array params in methods such as `find_items_advanced`, which would enable using `itemFilter` as described [here](http://developer.ebay.com/DevZone/finding/CallRef/findItemsAdvanced.html).

Here is a concrete example. I want to search for items in a given category, but I only want to see top rated sellers and sellers with a business type of `Business`. The URL would be (replace `app-id` with your app id):

http://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsAdvanced&SERVICE-VERSION=1.0.0&SECURITY-APPNAME=APP-ID&RESPONSE-DATA-FORMAT=JSON&RESTPAYLOAD=true&categoryId=267&itemFilter(0).name=SellerBusinessType&itemFilter(0).value=Business&itemFilter(1).name=TopRatedSellerOnly&itemFilter(1).value=true

Note `itemFilter(0)` and `itemFilter(1)`, which indicate an array of values. With the change I've introduced, one can do the following:

``` ruby
response = finder.find_items_advanced({
  categoryId: 267,
  outputSelector: 'SellerInfo',
  itemFilter: [{
    name: 'TopRatedSellerOnly',
    value: 'true'
  },{
    name: 'SellerBusinessType',
    value: 'Business'
  }]
})
```

What do you think about this?
