### PR TITLE
Use 1.8 compatible hash declaration

### DIFF
--- a/lib/rebay/finding.rb
+++ b/lib/rebay/finding.rb
@@ -8,7 +8,7 @@ module Rebay
     
     #http://developer.ebay.com/DevZone/finding/CallRef/findItemsAdvanced.html
     def find_items_advanced(params)
-      raise ArgumentError unless params[:keywords] or params[:categoryId]
+      raise ArgumentError unless params[:keywords] or params[:categoryId] or any_item_filter_names_match(params, 'Seller')
       response = get_json_response(build_request_url('findItemsAdvanced', params))
       response.trim(:findItemsAdvancedResponse)
       
@@ -17,7 +17,7 @@ module Rebay
       end
       return response
     end
-  
+
     #http://developer.ebay.com/DevZone/finding/CallRef/findItemsByCategory.html
     def find_items_by_category(params)
       raise ArgumentError unless params[:categoryId]
@@ -98,5 +98,10 @@ module Rebay
       url += build_rest_payload(params)
       return url
     end
+
+    def any_item_filter_names_match(params, test_name)
+      params.select { |k, v| k =~ /itemFilter\(\d+\)\.name/ && v == test_name }.any?
+    end
+
   end
 end

--- a/lib/rebay/shopping.rb
+++ b/lib/rebay/shopping.rb
@@ -129,7 +129,7 @@ module Rebay
     private
     def build_request_url(service, params=nil)
       url = "#{self.class.base_url}?callname=#{service}&appid=#{Rebay::Api.app_id}&version=#{VERSION}&responseencoding=JSON"
-      url += build_rest_payload({siteid: Rebay::Api.default_site_id}.merge(params))
+      url += build_rest_payload({:siteid => Rebay::Api.default_site_id}.merge(params))
       return url
     end
   end


### PR DESCRIPTION
For those poor souls stuck on ruby 1.8 who want to sample the latest(!) Rebay offering, replace the 'new' hash syntax with the old.
